### PR TITLE
reuse serverUrl for all job urls

### DIFF
--- a/tasks/jenkinsServer.js
+++ b/tasks/jenkinsServer.js
@@ -45,7 +45,11 @@ function JenkinsServer(serverUrl, defaultOptions, fileSystem, grunt) {
       }
       var jobs = JSON.parse(body).jobs;
       grunt.log.writeln(['Found', jobs.length, 'jobs.'].join(' '));
-      deferred.resolve(_.map(jobs, function(j) { return { name: j.name, url: j.url }; }));
+      deferred.resolve(_.map(jobs, function(j) {
+        var path = j.url.replace (/^https?\:\/{2}[^\/]+\/(.*)/, '$1');
+        var url = [serverUrl, path].join('/');
+        return { name: j.name, url: url };
+      }));
     });
 
     return deferred.promise;


### PR DESCRIPTION
Hello,

I have the problem to backup jenkins jobs from a Jenkins server that is running in a NAT network in a private cloud. I want to control it from outside from my host machine, as there is my cloned git repository.

My Gruntfile.js has a different IP address and port as Jenkins uses within the private cloud network for its Jenkins slaves.

``` javascript
module.exports = function(grunt) {
  grunt.initConfig({
    jenkins: {
      serverAddress: 'http://10.100.50.4:2200',
      username: 'YYYY',
      password: 'XXXX',
      pipelineDirectory: 'jenkins-configuration'
    }
  })
  grunt.loadNpmTasks('grunt-jenkins');
  grunt.registerTask('default', ['jenkins-list']);
};
```

If I list the jobs, you can see that the response from Jenkins returns a different IP address. That's the internal network for the jenkins swarm clients to connect to.

```
$ grunt jenkins-list
>> Using provided username and password

Running "jenkins-list-jobs" task
Found 8 jobs.
job: ubuntu1204-100gb_vcloud @ http://172.16.32.2/job/ubuntu1204-100gb_vcloud/
job: ubuntu1204-desktop_vcloud @ http://172.16.32.2/job/ubuntu1204-desktop_vcloud/
job: ubuntu1204_vcloud @ http://172.16.32.2/job/ubuntu1204_vcloud/
job: windows_2008_r2 @ http://172.16.32.2/job/windows_2008_r2/
job: windows_2008_r2_vcloud @ http://172.16.32.2/job/windows_2008_r2_vcloud/
job: windows_2012_r2_vcloud @ http://172.16.32.2/job/windows_2012_r2_vcloud/
job: windows_7_vcloud @ http://172.16.32.2/job/windows_7_vcloud/
job: windows_81_vcloud @ http://172.16.32.2/job/windows_81_vcloud/

Running "jenkins-list-plugins" task
plugin id: matrix-auth, version: 1.1
plugin id: matrix-project, version: 1.2
plugin id: pam-auth, version: 1.1
```

So the backup will hang as from my host machine I can't connect directly to that internal IP address. The result is this error after a long timeout:

```
$ grunt jenkins-backup
>> Using provided username and password

Running "jenkins-backup-jobs" task
Found 8 jobs.
Fatal error: Cannot read property 'statusCode' of undefined
```

I have changed the code that it reuses the given serverUrl from the Gruntfile.js and patches the responded urls for all jenkins jobs to have a correct url to connect to:

```
$ grunt jenkins-list
>> Using provided username and password

Running "jenkins-list-jobs" task
Found 8 jobs.
job: ubuntu1204-100gb_vcloud @ http://10.100.50.4:2200/job/ubuntu1204-100gb_vcloud/
job: ubuntu1204-desktop_vcloud @ http://10.100.50.4:2200/job/ubuntu1204-desktop_vcloud/
job: ubuntu1204_vcloud @ http://10.100.50.4:2200/job/ubuntu1204_vcloud/
job: windows_2008_r2 @ http://10.100.50.4:2200/job/windows_2008_r2/
job: windows_2008_r2_vcloud @ http://10.100.50.4:2200/job/windows_2008_r2_vcloud/
job: windows_2012_r2_vcloud @ http://10.100.50.4:2200/job/windows_2012_r2_vcloud/
job: windows_7_vcloud @ http://10.100.50.4:2200/job/windows_7_vcloud/
job: windows_81_vcloud @ http://10.100.50.4:2200/job/windows_81_vcloud/

Running "jenkins-list-plugins" task
plugin id: matrix-auth, version: 1.1
plugin id: matrix-project, version: 1.2
plugin id: pam-auth, version: 1.1
```

And then also the backup works from my host machine:

```
$ grunt jenkins-backup
>> Using provided username and password

Running "jenkins-backup-jobs" task
Found 8 jobs.
>> created file: jenkins-configuration/ubuntu1204-desktop_vcloud/config.xml
>> created file: jenkins-configuration/ubuntu1204_vcloud/config.xml
>> created file: jenkins-configuration/windows_2008_r2/config.xml
>> created file: jenkins-configuration/windows_2008_r2_vcloud/config.xml
>> created file: jenkins-configuration/windows_2012_r2_vcloud/config.xml
>> created file: jenkins-configuration/windows_7_vcloud/config.xml
>> created file: jenkins-configuration/ubuntu1204-100gb_vcloud/config.xml
>> created file: jenkins-configuration/windows_81_vcloud/config.xml

Running "jenkins-backup-plugins" task
>> created file: jenkins-configuration/plugins.json

Done, without errors.
```

The regex in the code replaces the protocol+host+port part and prepends the serverUrl. With that little change, which should work for all other 'normal' scenarios as well, I am even happier about this great automation tool!
